### PR TITLE
added imports to enable Mocha 'only' feature

### DIFF
--- a/server/test/cats.spec.ts
+++ b/server/test/cats.spec.ts
@@ -1,5 +1,6 @@
 import * as chai from 'chai';
 import * as chaiHttp from 'chai-http';
+import { describe, it } from 'mocha';
 
 process.env.NODE_ENV = 'test';
 import { app } from '../app';

--- a/server/test/users.spec.ts
+++ b/server/test/users.spec.ts
@@ -1,5 +1,6 @@
 import * as chai from 'chai';
 import * as chaiHttp from 'chai-http';
+import { describe, it } from 'mocha';
 
 process.env.NODE_ENV = 'test';
 import { app } from '../app';


### PR DESCRIPTION
As per [documentation](https://mochajs.org/#exclusive-tests), in Mocha I should be able to use `describe.only` and `it.only` in order to run just the selected tests and not all.

If I use `.only` in your code, it is not recognized as a valid property of `describe` or `it`.

I found the way to solve this: at the beginning of every test file you should add:

    import { it, describe } from 'mocha'

That's exactly what I did in my fork.

In this case I can add `only` and the tests run fine:

    it.only('test to execute', () => {
        // asserts
    })

    // OUTPUT is more or less:
    // run 1 of 12 - 'test to execute' passed